### PR TITLE
Other input requires description

### DIFF
--- a/src/features/TenantSupport/TenantSupport.tsx
+++ b/src/features/TenantSupport/TenantSupport.tsx
@@ -96,6 +96,7 @@ export const TenantSupport = () => {
   const extraDetailsRef = useRef<HTMLInputElement>(null);
   const [sendComplaint] = useSendComplaintMutation();
   const issueMap = new Map<string, { category: string; priority: string }>();
+  const isOther: boolean = selectedIssue.category === 'other' ? true : false;
   //Loop through each issue, loop through each option in that issue and get the issue category and priority for each label
   issues.forEach((issue) => {
     issue.options.forEach((option) => {
@@ -107,6 +108,7 @@ export const TenantSupport = () => {
   const handleChange = (event: SelectChangeEvent<string>) => {
     const currIssue = event.target.value;
     const issueDetails = issueMap.get(currIssue);
+
     if (issueDetails) {
       dispatch(setSelectedIssue({ subCategory: currIssue, ...issueDetails }));
     }
@@ -202,6 +204,7 @@ export const TenantSupport = () => {
                     id='issue-description'
                     multiline
                     rows={4}
+                    required={isOther}
                     variant='outlined'
                     inputRef={extraDetailsRef}
                     sx={{ width: '100%' }}


### PR DESCRIPTION
### **Description**
When user is on /tenant-support if they select Other as the complaint type then they will be required to enter a description before submitting.

### **Testing**
Select other from the dropdown menu and try submitting without a description and you shouldn't be able to submit, then try submitting with description and form should submit.

![tenantSupport_other](https://github.com/user-attachments/assets/200e1f28-1e8a-4aa2-a862-96c0e996e2b1)
